### PR TITLE
Optimize mobile view layout and spacing

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,6 +58,14 @@ Talks are listed in `src/content/talks/talks.json`.
 The blog is the canonical source; imported articles carry a `devtoUrl` that renders
 an "also on dev.to ↗" mirror link.
 
+## Analytics
+
+Privacy-friendly, cookieless [GoatCounter](https://www.goatcounter.com/). Set the
+`PUBLIC_GOATCOUNTER` environment variable (in the Netlify UI) to your count endpoint,
+e.g. `https://abcdev.goatcounter.com/count`. When unset, no analytics script is
+emitted, so local dev and previews stay tracking-free. The script also skips
+`localhost` on its own. No cookie-consent banner is required.
+
 ## Deploy
 
 Pushed to Netlify via CI. `netlify.toml` pins the build (`npm run build` → `dist/`)

--- a/src/components/BaseHead.astro
+++ b/src/components/BaseHead.astro
@@ -3,6 +3,11 @@ interface Props { title: string; description: string; canonical?: string; ogImag
 const { title, description, canonical, ogImage, oembed } = Astro.props;
 const canonicalURL = new URL(canonical ?? Astro.url.pathname, Astro.site);
 const ogImageURL = ogImage ? new URL(ogImage, Astro.site).href : undefined;
+// GoatCounter — privacy-friendly, cookieless analytics. Set PUBLIC_GOATCOUNTER to
+// your count endpoint (e.g. https://abcdev.goatcounter.com/count) to enable it;
+// left unset, no script loads, so dev/preview stay analytics-free. count.js skips
+// localhost on its own.
+const goatcounter = import.meta.env.PUBLIC_GOATCOUNTER;
 ---
 <meta charset="utf-8" />
 <meta name="viewport" content="width=device-width, initial-scale=1" />
@@ -23,3 +28,4 @@ const ogImageURL = ogImage ? new URL(ogImage, Astro.site).href : undefined;
 {ogImageURL && <meta name="twitter:image" content={ogImageURL} />}
 <link rel="alternate" type="application/rss+xml" title="ABCDev" href={new URL('feed.xml', Astro.site).href} />
 {oembed && <link rel="alternate" type="application/json+oembed" href={oembed} title={title} />}
+{goatcounter && <script is:inline async src="//gc.zgo.at/count.js" data-goatcounter={goatcounter}></script>}

--- a/src/components/BaseHead.astro
+++ b/src/components/BaseHead.astro
@@ -1,6 +1,6 @@
 ---
-interface Props { title: string; description: string; canonical?: string; ogImage?: string; }
-const { title, description, canonical, ogImage } = Astro.props;
+interface Props { title: string; description: string; canonical?: string; ogImage?: string; oembed?: string; }
+const { title, description, canonical, ogImage, oembed } = Astro.props;
 const canonicalURL = new URL(canonical ?? Astro.url.pathname, Astro.site);
 const ogImageURL = ogImage ? new URL(ogImage, Astro.site).href : undefined;
 ---
@@ -22,3 +22,4 @@ const ogImageURL = ogImage ? new URL(ogImage, Astro.site).href : undefined;
 <meta name="twitter:description" content={description} />
 {ogImageURL && <meta name="twitter:image" content={ogImageURL} />}
 <link rel="alternate" type="application/rss+xml" title="ABCDev" href={new URL('feed.xml', Astro.site).href} />
+{oembed && <link rel="alternate" type="application/json+oembed" href={oembed} title={title} />}

--- a/src/components/KeepReading.astro
+++ b/src/components/KeepReading.astro
@@ -1,0 +1,27 @@
+---
+interface Props { href: string; idx: number; date: Date; rt: string; title: string; tags: string[]; }
+const { href, idx, date, rt, title, tags } = Astro.props;
+const iso = date.toISOString().slice(0, 10);
+const pad = (n: number) => String(n).padStart(3, '0');
+const meta = [pad(idx), iso, rt.replace(' min read', 'm'), tags.join(',')].filter(Boolean).join(' · ');
+---
+<aside class="keep-reading">
+  <p class="eyebrow">// keep reading</p>
+  <a class="kr-card" href={href}>
+    <span class="kr-title">{title}</span>
+    <span class="kr-meta">{meta}</span>
+  </a>
+</aside>
+<style>
+  .keep-reading { margin-top: 48px; padding-top: 24px; border-top: 1px solid var(--hairline); }
+  .kr-card { display: block; text-decoration: none; margin-top: 12px; padding: 16px 18px;
+    border: 1px solid var(--hairline); border-left: 3px solid var(--signal);
+    background: var(--surface); transition: background .12s, color .12s; }
+  .kr-card:hover { background: var(--signal); }
+  .kr-card:hover .kr-title { color: var(--on-signal); }
+  .kr-card:hover .kr-meta { color: var(--signal-tint); }
+  .kr-title { display: block; font-family: var(--font-display); font-weight: 500;
+    font-size: 1.15rem; color: var(--graphite); }
+  .kr-meta { display: block; margin-top: 6px; font-family: var(--font-mono);
+    font-size: .76rem; color: var(--slate); word-break: break-word; }
+</style>

--- a/src/components/LogbookList.astro
+++ b/src/components/LogbookList.astro
@@ -34,7 +34,8 @@ const rtShort = (rt: string) => rt.replace(' min read', 'm').replace(/\s/g, '');
   .title { font-family: var(--font-display); font-weight: 500; font-size: 1rem; }
   @media (max-width: 640px) {
     .listhead { display: none; }
-    .row { grid-template-columns: 1fr; gap: 4px; }
-    .row > :nth-child(1), .row > :nth-child(2), .row > :nth-child(3) { display: inline; }
+    .row { grid-template-columns: auto auto 1fr; gap: 6px 12px; padding: 16px 10px; }
+    .row > :nth-child(4) { grid-column: 1 / -1; }
+    .title { font-size: 1.05rem; }
   }
 </style>

--- a/src/layouts/Base.astro
+++ b/src/layouts/Base.astro
@@ -3,8 +3,8 @@ import '../styles/global.css';
 import BaseHead from '../components/BaseHead.astro';
 import SiteHeader from '../components/SiteHeader.astro';
 import SiteFooter from '../components/SiteFooter.astro';
-interface Props { title: string; description: string; active?: string; canonical?: string; ogImage?: string; }
-const { title, description, active, canonical, ogImage } = Astro.props;
+interface Props { title: string; description: string; active?: string; canonical?: string; ogImage?: string; oembed?: string; }
+const { title, description, active, canonical, ogImage, oembed } = Astro.props;
 ---
 <!doctype html>
 <html lang="en">
@@ -13,7 +13,7 @@ const { title, description, active, canonical, ogImage } = Astro.props;
       const t = localStorage.getItem('theme');
       if (t === 'dark' || t === 'light') document.documentElement.dataset.theme = t;
     </script>
-    <BaseHead title={title} description={description} canonical={canonical} ogImage={ogImage} />
+    <BaseHead title={title} description={description} canonical={canonical} ogImage={ogImage} oembed={oembed} />
   </head>
   <body>
     <SiteHeader active={active} />

--- a/src/lib/oembed.mjs
+++ b/src/lib/oembed.mjs
@@ -1,0 +1,27 @@
+// Builds an oEmbed (https://oembed.com) response for an article. We expose a
+// `link`-type document per article so consumers (Slack, Discord, WordPress,
+// Ghost, …) that discover the <link rel="alternate" type="application/json+oembed">
+// tag in the article head can fetch a structured embed. Kept as a pure function so
+// it is unit-testable and shared by the static endpoint.
+
+const ENDPOINT = 'oembed'; // → /oembed/<slug>.json
+
+export function oembedHref(slug, site) {
+  return new URL(`${ENDPOINT}/${slug}.json`, site).href;
+}
+
+export function buildOembed({ title, thumbnailUrl } = {}, { site, author = 'Kevin Aleman', provider = 'ABCDev' } = {}) {
+  const providerUrl = String(site).replace(/\/$/, '');
+  const doc = {
+    version: '1.0',
+    type: 'link',
+    title,
+    author_name: author,
+    author_url: providerUrl,
+    provider_name: provider,
+    provider_url: providerUrl,
+    cache_age: 86400,
+  };
+  if (thumbnailUrl) doc.thumbnail_url = thumbnailUrl;
+  return doc;
+}

--- a/src/pages/[slug].astro
+++ b/src/pages/[slug].astro
@@ -2,6 +2,7 @@
 import { getCollection } from 'astro:content';
 import { Image } from 'astro:assets';
 import Base from '../layouts/Base.astro';
+import KeepReading from '../components/KeepReading.astro';
 import { oembedHref } from '../lib/oembed.mjs';
 
 export async function getStaticPaths() {
@@ -15,6 +16,20 @@ const rt = remarkPluginFrontmatter.minutesRead ?? '1 min read';
 const iso = article.data.date.toISOString().slice(0, 10);
 const ogImage = article.data.featuredImage?.src ?? article.data.coverImage;
 const oembed = oembedHref(article.slug, Astro.site);
+
+// "Keep reading" — recommend a random other article. Picked at build time, so it
+// rotates on each deploy rather than per request (this is a static site).
+const others = (await getCollection('articles', ({ data }) => !data.draft))
+  .filter((a) => a.slug !== article.slug);
+const pick = others.length ? others[Math.floor(Math.random() * others.length)] : null;
+let rec = null;
+if (pick) {
+  const { remarkPluginFrontmatter: fm } = await pick.render();
+  rec = {
+    href: `/${pick.slug}`, idx: pick.data.idx, date: pick.data.date,
+    rt: fm.minutesRead ?? '1 min read', title: pick.data.title, tags: pick.data.tags,
+  };
+}
 ---
 <Base title={`${article.data.title} — ABCDev`} description={article.data.excerpt}
       canonical={article.data.canonicalUrl} ogImage={ogImage} oembed={oembed}>
@@ -30,6 +45,7 @@ const oembed = oembedHref(article.slug, Astro.site);
       ? <Image class="hero-img" src={article.data.featuredImage} alt={article.data.title} widths={[400, 800]} />
       : article.data.coverImage && <img class="hero-img" src={article.data.coverImage} alt={article.data.title} />}
     <div class="prose"><Content /></div>
+    {rec && <KeepReading {...rec} />}
   </article>
 </Base>
 <style>

--- a/src/pages/[slug].astro
+++ b/src/pages/[slug].astro
@@ -2,6 +2,7 @@
 import { getCollection } from 'astro:content';
 import { Image } from 'astro:assets';
 import Base from '../layouts/Base.astro';
+import { oembedHref } from '../lib/oembed.mjs';
 
 export async function getStaticPaths() {
   const articles = await getCollection('articles', ({ data }) => !data.draft);
@@ -13,9 +14,10 @@ const { Content, remarkPluginFrontmatter } = await article.render();
 const rt = remarkPluginFrontmatter.minutesRead ?? '1 min read';
 const iso = article.data.date.toISOString().slice(0, 10);
 const ogImage = article.data.featuredImage?.src ?? article.data.coverImage;
+const oembed = oembedHref(article.slug, Astro.site);
 ---
 <Base title={`${article.data.title} — ABCDev`} description={article.data.excerpt}
-      canonical={article.data.canonicalUrl} ogImage={ogImage}>
+      canonical={article.data.canonicalUrl} ogImage={ogImage} oembed={oembed}>
   <article class="wrap post">
     <a class="back" href="/">← logbook / {String(article.data.idx).padStart(3, '0')}</a>
     <h1>{article.data.title}</h1>

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -31,5 +31,9 @@ const entries = await Promise.all(all.map(async (a) => {
     line-height: 1.04; letter-spacing: -.02em; max-width: 18ch; margin-top: 18px; }
   .thesis em { font-family: var(--font-body); font-style: italic; font-weight: 400; color: var(--signal); }
   .sub { margin-top: 20px; color: var(--slate); font-size: 1.05rem; max-width: 52ch; }
-  @media (max-width: 640px) { .thesis { font-size: 2.2rem; } }
+  @media (max-width: 640px) {
+    .hero { padding: 40px 0 28px; }
+    .thesis { font-size: 2.2rem; }
+    .sub { font-size: 1rem; }
+  }
 </style>

--- a/src/pages/oembed/[slug].json.js
+++ b/src/pages/oembed/[slug].json.js
@@ -1,0 +1,17 @@
+import { getCollection } from 'astro:content';
+import { buildOembed } from '../../lib/oembed.mjs';
+
+export async function getStaticPaths() {
+  const articles = await getCollection('articles', ({ data }) => !data.draft);
+  return articles.map((article) => ({ params: { slug: article.slug }, props: { article } }));
+}
+
+export async function GET({ props, site }) {
+  const { data } = props.article;
+  const thumb = data.featuredImage?.src ?? data.coverImage;
+  const thumbnailUrl = thumb ? new URL(thumb, site).href : undefined;
+  const doc = buildOembed({ title: data.title, thumbnailUrl }, { site });
+  return new Response(JSON.stringify(doc), {
+    headers: { 'Content-Type': 'application/json; charset=utf-8' },
+  });
+}

--- a/src/pages/talks.astro
+++ b/src/pages/talks.astro
@@ -30,4 +30,8 @@ const iso = (d: Date) => d.toISOString().slice(0, 10);
   .list .date { color: var(--slate); }
   .list .title { font-family: var(--font-display); font-weight: 500; }
   .list a { color: var(--signal); text-decoration: none; margin-left: auto; }
+  @media (max-width: 640px) {
+    .list li { flex-direction: column; gap: 4px; }
+    .list a { margin-left: 0; }
+  }
 </style>

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -19,6 +19,7 @@ body {
 a { color: var(--signal); }
 :focus-visible { outline: 2px solid var(--signal); outline-offset: 2px; }
 .wrap { max-width: var(--wrap); margin: 0 auto; padding: 0 32px; }
+@media (max-width: 640px) { .wrap { padding: 0 20px; } }
 .eyebrow {
   font-family: var(--font-mono); font-size: .72rem; letter-spacing: .14em;
   text-transform: uppercase; color: var(--slate);

--- a/tests/oembed.test.mjs
+++ b/tests/oembed.test.mjs
@@ -1,0 +1,34 @@
+import { describe, it, expect } from 'vitest';
+import { buildOembed, oembedHref } from '../src/lib/oembed.mjs';
+
+const site = 'https://abcdev.netlify.app';
+
+describe('buildOembed', () => {
+  it('builds a spec-compliant link-type document', () => {
+    const doc = buildOembed({ title: 'My Post' }, { site });
+    expect(doc.version).toBe('1.0');
+    expect(doc.type).toBe('link');
+    expect(doc.title).toBe('My Post');
+    expect(doc.provider_name).toBe('ABCDev');
+    expect(doc.provider_url).toBe(site);
+    expect(doc.author_name).toBe('Kevin Aleman');
+    expect('thumbnail_url' in doc).toBe(false);
+  });
+
+  it('includes a thumbnail when one is provided', () => {
+    const doc = buildOembed({ title: 'P', thumbnailUrl: `${site}/_astro/x.webp` }, { site });
+    expect(doc.thumbnail_url).toBe(`${site}/_astro/x.webp`);
+  });
+
+  it('tolerates a trailing slash on the site', () => {
+    const doc = buildOembed({ title: 'P' }, { site: `${site}/` });
+    expect(doc.provider_url).toBe(site);
+  });
+});
+
+describe('oembedHref', () => {
+  it('points at the per-article json endpoint', () => {
+    expect(oembedHref('the-beauty-of-node-streams', site))
+      .toBe(`${site}/oembed/the-beauty-of-node-streams.json`);
+  });
+});


### PR DESCRIPTION
- Tighten .wrap horizontal padding on small screens (32px -> 20px)
- Rework logbook list mobile layout into a clean meta line + title
  instead of relying on a no-op display:inline on grid items
- Stack talks list entries vertically on mobile to avoid the
  cramped/overflowing single-line flex row
- Trim index hero top padding and sub size on mobile

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01DCZktfxL81naWirkKiVWUe