### PR TITLE
Mobile polish, oEmbed, GoatCounter analytics, and "keep reading"

### DIFF
--- a/src/components/SiteFooter.astro
+++ b/src/components/SiteFooter.astro
@@ -14,7 +14,7 @@ const socials = [
 </footer>
 <style>
   footer { border-top: 1px solid var(--hairline); margin-top: 40px; }
-  .foot { display: flex; justify-content: space-between; padding: 26px 0;
+  .foot { display: flex; justify-content: space-between; padding-block: 26px;
     font-family: var(--font-mono); font-size: .74rem; color: var(--slate); }
   .foot a { color: var(--slate); text-decoration: none; }
   .foot a:hover { color: var(--signal); }

--- a/src/components/SiteHeader.astro
+++ b/src/components/SiteHeader.astro
@@ -23,7 +23,7 @@ const items = [
 </header>
 <style>
   header { border-bottom: 1px solid var(--hairline); }
-  .masthead { display: flex; align-items: baseline; justify-content: space-between; padding: 22px 0; }
+  .masthead { display: flex; align-items: baseline; justify-content: space-between; padding-block: 22px; }
   .wordmark { font-family: var(--font-display); font-weight: 700; font-size: 1.05rem;
     letter-spacing: .02em; color: var(--graphite); text-decoration: none; }
   .wordmark span { color: var(--slate); font-weight: 500; }

--- a/src/components/ThemeToggle.astro
+++ b/src/components/ThemeToggle.astro
@@ -6,11 +6,12 @@
 </button>
 <style>
   #theme-toggle {
-    font-family: var(--font-mono); font-size: .8rem; letter-spacing: .02em;
-    background: none; border: 0; padding: 0; margin-left: 22px; cursor: pointer;
-    color: var(--graphite);
+    font-family: var(--font-mono); font-size: .76rem; letter-spacing: .02em;
+    background: none; border: 1px solid var(--hairline); padding: 5px 10px;
+    margin-left: 22px; cursor: pointer; color: var(--graphite);
+    transition: border-color .12s, color .12s;
   }
-  #theme-toggle:hover { color: var(--signal); }
+  #theme-toggle:hover { color: var(--signal); border-color: var(--signal); }
   .on-dark { display: none; }
   :root[data-theme="dark"] .on-light { display: none; }
   :root[data-theme="dark"] .on-dark { display: inline; }


### PR DESCRIPTION
## Summary

A batch of front-end and content improvements to the blog:

### Mobile view
- Tighten `.wrap` horizontal padding on small screens (32px → 20px).
- Rework the logbook list mobile layout into a clean meta line + title instead of relying on a no-op `display: inline` on grid items.
- Stack the talks list vertically on mobile to avoid a cramped/overflowing single-line flex row.
- Trim the index hero's top padding and sub-text size on mobile.

### Header / footer / theme toggle
- Fix the masthead (and footer) **left margin**: `padding: Npx 0` was resetting the horizontal padding that `.wrap` supplies, leaving the wordmark flush against the viewport edge. Switched to `padding-block` so `.wrap`'s `padding: 0 32px` is preserved.
- Restyle the light/dark toggle as a bordered **button** so it reads as a control rather than plain nav text (it already toggles on click).

### oEmbed
- Each non-draft article now advertises an oEmbed document via a `<link rel="alternate" type="application/json+oembed">` tag in its head.
- A static `/oembed/<slug>.json` endpoint returns a spec-compliant `link`-type response (title, author, provider, thumbnail when available).

### Analytics
- Cookieless [GoatCounter](https://www.goatcounter.com/), loaded only when the `PUBLIC_GOATCOUNTER` env var is set, so dev/preview stay tracking-free. No cookie-consent banner required. Documented in the README.

### Keep reading
- Every article ends with a "keep reading" card recommending a random other article (picked at build time).

## Testing
- `npm run build`, `npm run check` (0 errors/warnings/hints), and `npm run test` (all passing).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01DCZktfxL81naWirkKiVWUe)_