### PR TITLE
Add search palette, per-post OG cards, article TOC + code copy, and a /stats page

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,11 @@ styled with a custom "Engineering Logbook" editorial design, and deployed to Net
 - Hand-written CSS design tokens (no Tailwind) — light mode, three typefaces
   (Space Grotesk / Newsreader / JetBrains Mono) self-hosted via `@fontsource`
 - **Shiki** for code highlighting, `remark-reading-time` for read times
-- RSS via `@astrojs/rss`; contact form via Netlify Forms
+- RSS via `@astrojs/rss`; sitemap via `@astrojs/sitemap`; contact form via Netlify Forms
+- Per-article social share cards rendered at build time with **satori** + **resvg**
+  (`src/pages/og/[slug].png.js`); `public/og-default.png` covers the non-article pages
+- Client-side ⌘K search palette (`SearchPalette.astro`) over an inlined index — no backend
+- `/stats` — the log in numbers (entries, words, read time, per-year and tag breakdowns)
 
 ## Develop
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -15,9 +15,11 @@
         "@fontsource/jetbrains-mono": "^5.0.0",
         "@fontsource/newsreader": "^5.0.0",
         "@fontsource/space-grotesk": "^5.0.0",
+        "@resvg/resvg-js": "^2.6.2",
         "astro": "^7.0.5",
         "mdast-util-to-string": "^4.0.0",
-        "reading-time": "^1.5.0"
+        "reading-time": "^1.5.0",
+        "satori": "^0.26.0"
       },
       "devDependencies": {
         "@astrojs/check": "^0.9.9",
@@ -1301,6 +1303,221 @@
         "url": "https://github.com/sponsors/Boshen"
       }
     },
+    "node_modules/@resvg/resvg-js": {
+      "version": "2.6.2",
+      "resolved": "https://registry.npmjs.org/@resvg/resvg-js/-/resvg-js-2.6.2.tgz",
+      "integrity": "sha512-xBaJish5OeGmniDj9cW5PRa/PtmuVU3ziqrbr5xJj901ZDN4TosrVaNZpEiLZAxdfnhAe7uQ7QFWfjPe9d9K2Q==",
+      "license": "MPL-2.0",
+      "engines": {
+        "node": ">= 10"
+      },
+      "optionalDependencies": {
+        "@resvg/resvg-js-android-arm-eabi": "2.6.2",
+        "@resvg/resvg-js-android-arm64": "2.6.2",
+        "@resvg/resvg-js-darwin-arm64": "2.6.2",
+        "@resvg/resvg-js-darwin-x64": "2.6.2",
+        "@resvg/resvg-js-linux-arm-gnueabihf": "2.6.2",
+        "@resvg/resvg-js-linux-arm64-gnu": "2.6.2",
+        "@resvg/resvg-js-linux-arm64-musl": "2.6.2",
+        "@resvg/resvg-js-linux-x64-gnu": "2.6.2",
+        "@resvg/resvg-js-linux-x64-musl": "2.6.2",
+        "@resvg/resvg-js-win32-arm64-msvc": "2.6.2",
+        "@resvg/resvg-js-win32-ia32-msvc": "2.6.2",
+        "@resvg/resvg-js-win32-x64-msvc": "2.6.2"
+      }
+    },
+    "node_modules/@resvg/resvg-js-android-arm-eabi": {
+      "version": "2.6.2",
+      "resolved": "https://registry.npmjs.org/@resvg/resvg-js-android-arm-eabi/-/resvg-js-android-arm-eabi-2.6.2.tgz",
+      "integrity": "sha512-FrJibrAk6v29eabIPgcTUMPXiEz8ssrAk7TXxsiZzww9UTQ1Z5KAbFJs+Z0Ez+VZTYgnE5IQJqBcoSiMebtPHA==",
+      "cpu": [
+        "arm"
+      ],
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@resvg/resvg-js-android-arm64": {
+      "version": "2.6.2",
+      "resolved": "https://registry.npmjs.org/@resvg/resvg-js-android-arm64/-/resvg-js-android-arm64-2.6.2.tgz",
+      "integrity": "sha512-VcOKezEhm2VqzXpcIJoITuvUS/fcjIw5NA/w3tjzWyzmvoCdd+QXIqy3FBGulWdClvp4g+IfUemigrkLThSjAQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@resvg/resvg-js-darwin-arm64": {
+      "version": "2.6.2",
+      "resolved": "https://registry.npmjs.org/@resvg/resvg-js-darwin-arm64/-/resvg-js-darwin-arm64-2.6.2.tgz",
+      "integrity": "sha512-nmok2LnAd6nLUKI16aEB9ydMC6Lidiiq2m1nEBDR1LaaP7FGs4AJ90qDraxX+CWlVuRlvNjyYJTNv8qFjtL9+A==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@resvg/resvg-js-darwin-x64": {
+      "version": "2.6.2",
+      "resolved": "https://registry.npmjs.org/@resvg/resvg-js-darwin-x64/-/resvg-js-darwin-x64-2.6.2.tgz",
+      "integrity": "sha512-GInyZLjgWDfsVT6+SHxQVRwNzV0AuA1uqGsOAW+0th56J7Nh6bHHKXHBWzUrihxMetcFDmQMAX1tZ1fZDYSRsw==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@resvg/resvg-js-linux-arm-gnueabihf": {
+      "version": "2.6.2",
+      "resolved": "https://registry.npmjs.org/@resvg/resvg-js-linux-arm-gnueabihf/-/resvg-js-linux-arm-gnueabihf-2.6.2.tgz",
+      "integrity": "sha512-YIV3u/R9zJbpqTTNwTZM5/ocWetDKGsro0SWp70eGEM9eV2MerWyBRZnQIgzU3YBnSBQ1RcxRZvY/UxwESfZIw==",
+      "cpu": [
+        "arm"
+      ],
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@resvg/resvg-js-linux-arm64-gnu": {
+      "version": "2.6.2",
+      "resolved": "https://registry.npmjs.org/@resvg/resvg-js-linux-arm64-gnu/-/resvg-js-linux-arm64-gnu-2.6.2.tgz",
+      "integrity": "sha512-zc2BlJSim7YR4FZDQ8OUoJg5holYzdiYMeobb9pJuGDidGL9KZUv7SbiD4E8oZogtYY42UZEap7dqkkYuA91pg==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@resvg/resvg-js-linux-arm64-musl": {
+      "version": "2.6.2",
+      "resolved": "https://registry.npmjs.org/@resvg/resvg-js-linux-arm64-musl/-/resvg-js-linux-arm64-musl-2.6.2.tgz",
+      "integrity": "sha512-3h3dLPWNgSsD4lQBJPb4f+kvdOSJHa5PjTYVsWHxLUzH4IFTJUAnmuWpw4KqyQ3NA5QCyhw4TWgxk3jRkQxEKg==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@resvg/resvg-js-linux-x64-gnu": {
+      "version": "2.6.2",
+      "resolved": "https://registry.npmjs.org/@resvg/resvg-js-linux-x64-gnu/-/resvg-js-linux-x64-gnu-2.6.2.tgz",
+      "integrity": "sha512-IVUe+ckIerA7xMZ50duAZzwf1U7khQe2E0QpUxu5MBJNao5RqC0zwV/Zm965vw6D3gGFUl7j4m+oJjubBVoftw==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@resvg/resvg-js-linux-x64-musl": {
+      "version": "2.6.2",
+      "resolved": "https://registry.npmjs.org/@resvg/resvg-js-linux-x64-musl/-/resvg-js-linux-x64-musl-2.6.2.tgz",
+      "integrity": "sha512-UOf83vqTzoYQO9SZ0fPl2ZIFtNIz/Rr/y+7X8XRX1ZnBYsQ/tTb+cj9TE+KHOdmlTFBxhYzVkP2lRByCzqi4jQ==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@resvg/resvg-js-win32-arm64-msvc": {
+      "version": "2.6.2",
+      "resolved": "https://registry.npmjs.org/@resvg/resvg-js-win32-arm64-msvc/-/resvg-js-win32-arm64-msvc-2.6.2.tgz",
+      "integrity": "sha512-7C/RSgCa+7vqZ7qAbItfiaAWhyRSoD4l4BQAbVDqRRsRgY+S+hgS3in0Rxr7IorKUpGE69X48q6/nOAuTJQxeQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@resvg/resvg-js-win32-ia32-msvc": {
+      "version": "2.6.2",
+      "resolved": "https://registry.npmjs.org/@resvg/resvg-js-win32-ia32-msvc/-/resvg-js-win32-ia32-msvc-2.6.2.tgz",
+      "integrity": "sha512-har4aPAlvjnLcil40AC77YDIk6loMawuJwFINEM7n0pZviwMkMvjb2W5ZirsNOZY4aDbo5tLx0wNMREp5Brk+w==",
+      "cpu": [
+        "ia32"
+      ],
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@resvg/resvg-js-win32-x64-msvc": {
+      "version": "2.6.2",
+      "resolved": "https://registry.npmjs.org/@resvg/resvg-js-win32-x64-msvc/-/resvg-js-win32-x64-msvc-2.6.2.tgz",
+      "integrity": "sha512-ZXtYhtUr5SSaBrUDq7DiyjOFJqBVL/dOBN7N/qmi/pO0IgiWW/f/ue3nbvu9joWE5aAKDoIzy/CxsY0suwGosQ==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
     "node_modules/@rolldown/binding-android-arm64": {
       "version": "1.1.4",
       "resolved": "https://registry.npmjs.org/@rolldown/binding-android-arm64/-/binding-android-arm64-1.1.4.tgz",
@@ -2026,6 +2243,22 @@
       "resolved": "https://registry.npmjs.org/@shikijs/vscode-textmate/-/vscode-textmate-10.0.2.tgz",
       "integrity": "sha512-83yeghZ2xxin3Nj8z1NMd/NCuca+gsYXswywDy5bHvwlWL8tpTQmzGeUuHd9FC3E/SBEMvzJRwWEOz5gGes9Qg==",
       "license": "MIT"
+    },
+    "node_modules/@shuding/opentype.js": {
+      "version": "1.4.0-beta.0",
+      "resolved": "https://registry.npmjs.org/@shuding/opentype.js/-/opentype.js-1.4.0-beta.0.tgz",
+      "integrity": "sha512-3NgmNyH3l/Hv6EvsWJbsvpcpUba6R8IREQ83nH83cyakCw7uM1arZKNfHwv1Wz6jgqrF/j4x5ELvR6PnK9nTcA==",
+      "license": "MIT",
+      "dependencies": {
+        "fflate": "^0.7.3",
+        "string.prototype.codepointat": "^0.2.1"
+      },
+      "bin": {
+        "ot": "bin/ot"
+      },
+      "engines": {
+        "node": ">= 8.0.0"
+      }
     },
     "node_modules/@standard-schema/spec": {
       "version": "1.1.0",
@@ -2982,11 +3215,29 @@
         "url": "https://github.com/sponsors/wooorm"
       }
     },
+    "node_modules/base64-js": {
+      "version": "0.0.8",
+      "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-0.0.8.tgz",
+      "integrity": "sha512-3XSA2cR/h/73EzlXXdU6YNycmYI7+kicTxks4eJg2g39biHR84slg2+des+p7iHYhbRg/udIS4TD53WabcOUkw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
     "node_modules/boolbase": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/boolbase/-/boolbase-1.0.0.tgz",
       "integrity": "sha512-JZOSA7Mo9sNGB8+UjSgzdLtokWAky1zbztM3WRLCbZ70/3cTANmQmOdR7y2g+J0e2WXywy1yS468tY+IruqEww==",
       "license": "ISC"
+    },
+    "node_modules/camelize": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/camelize/-/camelize-1.0.1.tgz",
+      "integrity": "sha512-dU+Tx2fsypxTgtLoE36npi3UqcjSSMNYfkqgmoEhtZrraP5VWq0K7FkWVTYa8eMPtnU/G2txVsfdCJTn9uzpuQ==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
     },
     "node_modules/ccount": {
       "version": "2.0.1",
@@ -3189,7 +3440,6 @@
       "version": "1.1.4",
       "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
       "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/comma-separated-tokens": {
@@ -3255,6 +3505,36 @@
         "uncrypto": "^0.1.3"
       }
     },
+    "node_modules/css-background-parser": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/css-background-parser/-/css-background-parser-0.1.0.tgz",
+      "integrity": "sha512-2EZLisiZQ+7m4wwur/qiYJRniHX4K5Tc9w93MT3AS0WS1u5kaZ4FKXlOTBhOjc+CgEgPiGY+fX1yWD8UwpEqUA==",
+      "license": "MIT"
+    },
+    "node_modules/css-box-shadow": {
+      "version": "1.0.0-3",
+      "resolved": "https://registry.npmjs.org/css-box-shadow/-/css-box-shadow-1.0.0-3.tgz",
+      "integrity": "sha512-9jaqR6e7Ohds+aWwmhe6wILJ99xYQbfmK9QQB9CcMjDbTxPZjwEmUQpU91OG05Xgm8BahT5fW+svbsQGjS/zPg==",
+      "license": "MIT"
+    },
+    "node_modules/css-color-keywords": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/css-color-keywords/-/css-color-keywords-1.0.0.tgz",
+      "integrity": "sha512-FyyrDHZKEjXDpNJYvVsV960FiqQyXc/LlYmsxl2BcdMb2WPx0OGRVgTg55rPSyLSNMqP52R9r8geSp7apN3Ofg==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/css-gradient-parser": {
+      "version": "0.0.17",
+      "resolved": "https://registry.npmjs.org/css-gradient-parser/-/css-gradient-parser-0.0.17.tgz",
+      "integrity": "sha512-w2Xy9UMMwlKtou0vlRnXvWglPAceXCTtcmVSo8ZBUvqCV5aXEFP/PC6d+I464810I9FT++UACwTD5511bmGPUg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=16"
+      }
+    },
     "node_modules/css-select": {
       "version": "5.2.2",
       "resolved": "https://registry.npmjs.org/css-select/-/css-select-5.2.2.tgz",
@@ -3269,6 +3549,17 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/fb55"
+      }
+    },
+    "node_modules/css-to-react-native": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/css-to-react-native/-/css-to-react-native-3.2.0.tgz",
+      "integrity": "sha512-e8RKaLXMOFii+02mOlqwjbD00KSEKqblnpO9e++1aXS1fPQOpS1YoqdVHBqPjHNoxeF2mimzVqawm2KCbEdtHQ==",
+      "license": "MIT",
+      "dependencies": {
+        "camelize": "^1.0.0",
+        "css-color-keywords": "^1.0.0",
+        "postcss-value-parser": "^4.0.2"
       }
     },
     "node_modules/css-tree": {
@@ -3498,6 +3789,15 @@
         "@emmetio/css-abbreviation": "^2.1.8"
       }
     },
+    "node_modules/emoji-regex-xs": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/emoji-regex-xs/-/emoji-regex-xs-2.0.1.tgz",
+      "integrity": "sha512-1QFuh8l7LqUcKe24LsPUNzjrzJQ7pgRwp1QMcZ5MX6mFplk2zQ08NVCM84++1cveaUUYtcCYHmeFEuNg16sU4g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.0.0"
+      }
+    },
     "node_modules/entities": {
       "version": "4.5.0",
       "resolved": "https://registry.npmjs.org/entities/-/entities-4.5.0.tgz",
@@ -3525,6 +3825,12 @@
       "engines": {
         "node": ">=6"
       }
+    },
+    "node_modules/escape-html": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.3.tgz",
+      "integrity": "sha512-NiSupZ4OeuGwr68lGIeym/ksIZMJodUGOSCZ/FSnTxcrekbvqrgdUxlJOMpijaKZVjAJrWrGs/6Jy8OMuyj9ow==",
+      "license": "MIT"
     },
     "node_modules/escape-string-regexp": {
       "version": "5.0.0",
@@ -3673,6 +3979,12 @@
           "optional": true
         }
       }
+    },
+    "node_modules/fflate": {
+      "version": "0.7.4",
+      "resolved": "https://registry.npmjs.org/fflate/-/fflate-0.7.4.tgz",
+      "integrity": "sha512-5u2V/CDW15QM1XbbgS+0DfPxVB+jUKhWEKuuFuHncbk3tEEqzmoXL+2KyOFuKGqOnmdIy0/davWF1CkuwtibCw==",
+      "license": "MIT"
     },
     "node_modules/flattie": {
       "version": "1.1.1",
@@ -3941,6 +4253,18 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/hex-rgb": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/hex-rgb/-/hex-rgb-4.3.0.tgz",
+      "integrity": "sha512-Ox1pJVrDCyGHMG9CFg1tmrRUMRPRsAWYc/PinY0XzJU4K7y7vjNoLKIQ7BR5UJMCxNN8EM1MNDmHWA/B3aZUuw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/html-escaper": {
@@ -4364,6 +4688,16 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/linebreak": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/linebreak/-/linebreak-1.1.0.tgz",
+      "integrity": "sha512-MHp03UImeVhB7XZtjd0E4n6+3xr5Dq/9xI/5FptGk5FrbDR3zagPa2DS6U8ks/3HjbKWG9Q1M2ufOzxV2qLYSQ==",
+      "license": "MIT",
+      "dependencies": {
+        "base64-js": "0.0.8",
+        "unicode-trie": "^2.0.0"
       }
     },
     "node_modules/longest-streak": {
@@ -5400,6 +5734,22 @@
       "integrity": "sha512-xg1eHpwYL/D/HEdWw2goFZP6vV0FH7W+PZ5rFkGjdIDLtxq7EkzBUeT3m+lndYCt8wKbmofUu1MUdMCXkCk9ZQ==",
       "license": "MIT"
     },
+    "node_modules/pako": {
+      "version": "0.2.9",
+      "resolved": "https://registry.npmjs.org/pako/-/pako-0.2.9.tgz",
+      "integrity": "sha512-NUcwaKxUxWrZLpDG+z/xZaCgQITkA/Dv4V/T6bw7VON6l1Xz/VnrBqrYjZQ12TamKHzITTfOEIYUj48y2KXImA==",
+      "license": "MIT"
+    },
+    "node_modules/parse-css-color": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/parse-css-color/-/parse-css-color-0.2.1.tgz",
+      "integrity": "sha512-bwS/GGIFV3b6KS4uwpzCFj4w297Yl3uqnSgIPsoQkx7GMLROXfMnWvxfNkL0oh8HVhZA4hvJoEoEIqonfJ3BWg==",
+      "license": "MIT",
+      "dependencies": {
+        "color-name": "^1.1.4",
+        "hex-rgb": "^4.1.0"
+      }
+    },
     "node_modules/parse-latin": {
       "version": "7.0.0",
       "resolved": "https://registry.npmjs.org/parse-latin/-/parse-latin-7.0.0.tgz",
@@ -5522,6 +5872,12 @@
       "engines": {
         "node": "^10 || ^12 || >=14"
       }
+    },
+    "node_modules/postcss-value-parser": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/postcss-value-parser/-/postcss-value-parser-4.2.0.tgz",
+      "integrity": "sha512-1NNCs6uurfkVbeXG4S8JFT9t19m45ICnif8zWLd5oPSZ50QnwMfK+H3jv408d4jw/7Bttv5axS5IiHoLaVNHeQ==",
+      "license": "MIT"
     },
     "node_modules/prettier": {
       "version": "3.8.4",
@@ -5904,6 +6260,28 @@
         "fsevents": "~2.3.2"
       }
     },
+    "node_modules/satori": {
+      "version": "0.26.0",
+      "resolved": "https://registry.npmjs.org/satori/-/satori-0.26.0.tgz",
+      "integrity": "sha512-tkMFrfIs3l2mQ2JEcyW0ADTy3zGggFRFzi6Ef8YozQSFsFKEqaSO1Y8F9wJg4//PJGQauMalHGTUEkPrFwhVPA==",
+      "license": "MPL-2.0",
+      "dependencies": {
+        "@shuding/opentype.js": "1.4.0-beta.0",
+        "css-background-parser": "^0.1.0",
+        "css-box-shadow": "1.0.0-3",
+        "css-gradient-parser": "^0.0.17",
+        "css-to-react-native": "^3.0.0",
+        "emoji-regex-xs": "^2.0.1",
+        "escape-html": "^1.0.3",
+        "linebreak": "^1.1.0",
+        "parse-css-color": "^0.2.1",
+        "postcss-value-parser": "^4.2.0",
+        "yoga-layout": "^3.2.1"
+      },
+      "engines": {
+        "node": ">=16"
+      }
+    },
     "node_modules/satteri": {
       "version": "0.9.4",
       "resolved": "https://registry.npmjs.org/satteri/-/satteri-0.9.4.tgz",
@@ -6099,6 +6477,12 @@
       "integrity": "sha512-TlnjJ1C0QrmxRNrON00JvaFFlNh5TTG00APw23j74ET7gkQpTASi6/L2fuiav8pzK715HXtUeClpBTw2NPSn6w==",
       "license": "MIT"
     },
+    "node_modules/string.prototype.codepointat": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/string.prototype.codepointat/-/string.prototype.codepointat-0.2.1.tgz",
+      "integrity": "sha512-2cBVCj6I4IOvEnjgO/hWqXjqBGsY+zwPmHl12Srk9IXSZ56Jwwmy+66XO5Iut/oQVR7t5ihYdLB0GMa4alEUcg==",
+      "license": "MIT"
+    },
     "node_modules/stringify-entities": {
       "version": "4.0.4",
       "resolved": "https://registry.npmjs.org/stringify-entities/-/stringify-entities-4.0.4.tgz",
@@ -6291,6 +6675,16 @@
       "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.18.2.tgz",
       "integrity": "sha512-AsuCzffGHJybSaRrmr5eHr81mwJU3kjw6M+uprWvCXiNeN9SOGwQ3Jn8jb8m3Z6izVgknn1R0FTCEAP2QrLY/w==",
       "license": "MIT"
+    },
+    "node_modules/unicode-trie": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/unicode-trie/-/unicode-trie-2.0.0.tgz",
+      "integrity": "sha512-x7bc76x0bm4prf1VLg79uhAzKw8DVboClSN5VxJuQ+LKDOVEW9CdH+VY7SP+vX7xCYQqzzgQpFqz15zeLvAtZQ==",
+      "license": "MIT",
+      "dependencies": {
+        "pako": "^0.2.5",
+        "tiny-inflate": "^1.0.0"
+      }
     },
     "node_modules/unified": {
       "version": "11.0.5",
@@ -7325,6 +7719,12 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
+    },
+    "node_modules/yoga-layout": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/yoga-layout/-/yoga-layout-3.2.1.tgz",
+      "integrity": "sha512-0LPOt3AxKqMdFBZA3HBAt/t/8vIKq7VaQYbuA8WxCgung+p9TVyKRYdpvCb80HcdTN2NkbIKbhNwKUfm3tQywQ==",
+      "license": "MIT"
     },
     "node_modules/zod": {
       "version": "4.4.3",

--- a/package.json
+++ b/package.json
@@ -19,9 +19,11 @@
     "@fontsource/jetbrains-mono": "^5.0.0",
     "@fontsource/newsreader": "^5.0.0",
     "@fontsource/space-grotesk": "^5.0.0",
+    "@resvg/resvg-js": "^2.6.2",
     "astro": "^7.0.5",
     "mdast-util-to-string": "^4.0.0",
-    "reading-time": "^1.5.0"
+    "reading-time": "^1.5.0",
+    "satori": "^0.26.0"
   },
   "devDependencies": {
     "@astrojs/check": "^0.9.9",

--- a/src/components/SearchPalette.astro
+++ b/src/components/SearchPalette.astro
@@ -1,0 +1,170 @@
+---
+// Command-palette search over the whole logbook. The index is tiny (title, tags,
+// excerpt per entry) and inlined into every page at build time, so search is
+// instant and needs no backend. Opens with ⌘K / ctrl+K / "/", or the nav button.
+import { getCollection } from 'astro:content';
+
+const arts = (await getCollection('articles', ({ data }) => !data.draft))
+  .sort((a, b) => b.data.date.getTime() - a.data.date.getTime());
+const index = arts.map((a) => ({
+  slug: a.id,
+  idx: a.data.idx,
+  date: a.data.date.toISOString().slice(0, 10),
+  title: a.data.title,
+  tags: a.data.tags,
+  excerpt: a.data.excerpt,
+}));
+---
+<dialog id="search" aria-label="Search the logbook">
+  <div class="search-head">
+    <input id="search-input" type="text" placeholder="search entries…" autocomplete="off"
+      spellcheck="false" role="combobox" aria-expanded="true" aria-controls="search-results"
+      aria-label="Search entries" />
+    <span class="search-count" data-search-count aria-live="polite"></span>
+  </div>
+  <ol id="search-results" role="listbox" aria-label="Results"></ol>
+  <div class="search-foot">
+    <span>↑↓ navigate</span><span>↵ open</span><span>esc close</span>
+  </div>
+</dialog>
+<script type="application/json" id="search-data" set:html={JSON.stringify(index)}></script>
+<script is:inline>
+  (() => {
+    const dialog = document.getElementById('search');
+    if (!dialog || !dialog.showModal) return;
+    const input = document.getElementById('search-input');
+    const list = document.getElementById('search-results');
+    const count = dialog.querySelector('[data-search-count]');
+    const data = JSON.parse(document.getElementById('search-data').textContent);
+    let results = [];
+    let active = 0;
+
+    const score = (e, tokens) => {
+      const title = e.title.toLowerCase();
+      const tags = e.tags.join(' ').toLowerCase();
+      const excerpt = e.excerpt.toLowerCase();
+      let total = 0;
+      for (const t of tokens) {
+        let s = 0;
+        if (title.startsWith(t)) s = 4;
+        else if (title.includes(t)) s = 3;
+        else if (tags.includes(t)) s = 2;
+        else if (excerpt.includes(t)) s = 1;
+        if (!s) return 0; // every token must match somewhere
+        total += s;
+      }
+      return total;
+    };
+
+    const renderRows = () => {
+      list.textContent = '';
+      results.forEach((e, i) => {
+        const li = document.createElement('li');
+        li.role = 'option';
+        li.id = `search-opt-${i}`;
+        li.setAttribute('aria-selected', String(i === active));
+        if (i === active) li.classList.add('active');
+        const a = document.createElement('a');
+        a.href = `/${e.slug}`;
+        a.tabIndex = -1;
+        const mk = (cls, text) => {
+          const s = document.createElement('span');
+          s.className = cls; s.textContent = text;
+          return s;
+        };
+        a.append(
+          mk('r-idx', String(e.idx).padStart(3, '0')),
+          mk('r-date', e.date),
+          mk('r-title', e.title),
+          mk('r-tags', e.tags.join(',')),
+        );
+        li.addEventListener('mousemove', () => { if (active !== i) { active = i; renderRows(); } });
+        li.appendChild(a);
+        list.appendChild(li);
+      });
+      input.setAttribute('aria-activedescendant', results.length ? `search-opt-${active}` : '');
+      count.textContent = `${results.length} ${results.length === 1 ? 'entry' : 'entries'}`;
+      if (!results.length) {
+        const li = document.createElement('li');
+        li.className = 'empty';
+        li.textContent = 'no entries match';
+        list.appendChild(li);
+      }
+    };
+
+    const search = () => {
+      const tokens = input.value.toLowerCase().split(/\s+/).filter(Boolean);
+      results = !tokens.length ? [...data]
+        : data.map((e) => [score(e, tokens), e]).filter(([s]) => s > 0)
+            .sort((a, b) => b[0] - a[0]).map(([, e]) => e);
+      active = 0;
+      renderRows();
+    };
+
+    const open = () => { dialog.showModal(); input.select(); search(); };
+    const toggle = () => (dialog.open ? dialog.close() : open());
+
+    input.addEventListener('input', search);
+    input.addEventListener('keydown', (ev) => {
+      if (ev.key === 'ArrowDown' || ev.key === 'ArrowUp') {
+        ev.preventDefault();
+        if (!results.length) return;
+        active = (active + (ev.key === 'ArrowDown' ? 1 : -1) + results.length) % results.length;
+        renderRows();
+        list.querySelector('.active')?.scrollIntoView({ block: 'nearest' });
+      } else if (ev.key === 'Enter' && results[active]) {
+        location.href = `/${results[active].slug}`;
+      }
+    });
+    // Close when the backdrop (the dialog element itself) is clicked.
+    dialog.addEventListener('click', (ev) => { if (ev.target === dialog) dialog.close(); });
+
+    document.addEventListener('keydown', (ev) => {
+      if ((ev.metaKey || ev.ctrlKey) && ev.key.toLowerCase() === 'k') { ev.preventDefault(); toggle(); }
+      else if (ev.key === '/' && !dialog.open && !/^(input|textarea|select)$/i.test(ev.target.tagName)) {
+        ev.preventDefault(); open();
+      }
+    });
+
+    const btn = document.getElementById('search-open');
+    if (btn) {
+      btn.hidden = false;
+      const kbd = btn.querySelector('kbd');
+      if (kbd && !/mac/i.test(navigator.platform)) kbd.textContent = 'ctrl k';
+      btn.addEventListener('click', open);
+    }
+  })();
+</script>
+<style>
+  #search { width: min(640px, calc(100vw - 40px)); margin: 12vh auto auto; padding: 0;
+    background: var(--bone); color: var(--graphite); border: 1px solid var(--hairline); }
+  #search::backdrop { background: rgba(21, 24, 27, .45); }
+  .search-head { display: flex; align-items: baseline; gap: 14px; padding: 16px 18px;
+    border-bottom: 1px solid var(--hairline); }
+  #search-input { flex: 1; min-width: 0; font-family: var(--font-mono); font-size: .95rem;
+    background: none; border: 0; color: var(--graphite); }
+  #search-input:focus { outline: none; }
+  #search-input::placeholder { color: var(--slate); }
+  .search-count { font-family: var(--font-mono); font-size: .7rem; color: var(--slate); white-space: nowrap; }
+  #search-results { list-style: none; margin: 0; padding: 0; max-height: 46vh; overflow-y: auto; }
+  #search-results :global(li) { border-bottom: 1px solid var(--hairline); }
+  #search-results :global(a) { display: grid; grid-template-columns: 38px 92px 1fr; gap: 6px 14px;
+    align-items: baseline; padding: 11px 18px; font-family: var(--font-mono); font-size: .78rem;
+    color: var(--graphite); text-decoration: none; }
+  #search-results :global(.r-idx), #search-results :global(.r-date), #search-results :global(.r-tags) { color: var(--slate); }
+  #search-results :global(.r-title) { font-family: var(--font-display); font-weight: 500; font-size: .95rem; }
+  #search-results :global(.r-tags) { grid-column: 3; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+  #search-results :global(li.active a) { background: var(--signal); color: var(--on-signal); }
+  #search-results :global(li.active .r-idx), #search-results :global(li.active .r-date),
+  #search-results :global(li.active .r-tags) { color: var(--signal-tint); }
+  #search-results :global(li.empty) { padding: 16px 18px; font-family: var(--font-mono);
+    font-size: .8rem; color: var(--slate); }
+  .search-foot { display: flex; gap: 18px; padding: 10px 18px; border-top: 1px solid var(--hairline);
+    font-family: var(--font-mono); font-size: .68rem; color: var(--slate); }
+  @media (max-width: 520px) {
+    #search-results :global(a) { grid-template-columns: 38px 1fr; }
+    #search-results :global(.r-date) { display: none; }
+    #search-results :global(.r-tags) { grid-column: 2; }
+    .search-foot { display: none; }
+  }
+</style>

--- a/src/components/SiteHeader.astro
+++ b/src/components/SiteHeader.astro
@@ -6,6 +6,7 @@ const items = [
   { href: '/', label: 'logbook', key: 'logbook' },
   { href: '/about', label: 'about', key: 'about' },
   { href: '/talks', label: 'talks', key: 'talks' },
+  { href: '/stats', label: 'stats', key: 'stats' },
   { href: '/contact', label: 'contact', key: 'contact' },
   { href: '/feed.xml', label: 'feed', key: 'feed' },
 ];
@@ -17,6 +18,7 @@ const items = [
       {items.map((i) => (
         <a href={i.href} class={active === i.key ? 'active' : ''}>{i.label}</a>
       ))}
+      <button id="search-open" type="button" hidden aria-label="Search the logbook">search <kbd>⌘k</kbd></button>
       <ThemeToggle />
     </nav>
   </div>
@@ -30,8 +32,15 @@ const items = [
   nav { font-family: var(--font-mono); font-size: .8rem; }
   nav a { color: var(--graphite); text-decoration: none; margin-left: 22px; }
   nav a:hover, nav a.active { color: var(--signal); }
+  #search-open { font-family: var(--font-mono); font-size: .8rem; background: none; border: 0;
+    padding: 0; margin-left: 22px; color: var(--graphite); cursor: pointer; }
+  #search-open:hover { color: var(--signal); }
+  #search-open kbd { font-family: var(--font-mono); font-size: .68rem; color: var(--slate);
+    border: 1px solid var(--hairline); padding: 1px 5px; margin-left: 2px; }
   @media (max-width: 640px) {
     .masthead { flex-direction: column; gap: 12px; align-items: flex-start; }
     nav a { margin-left: 0; margin-right: 18px; }
+    #search-open { margin-left: 0; margin-right: 18px; }
+    #search-open kbd { display: none; }
   }
 </style>

--- a/src/layouts/Base.astro
+++ b/src/layouts/Base.astro
@@ -3,6 +3,7 @@ import '../styles/global.css';
 import BaseHead from '../components/BaseHead.astro';
 import SiteHeader from '../components/SiteHeader.astro';
 import SiteFooter from '../components/SiteFooter.astro';
+import SearchPalette from '../components/SearchPalette.astro';
 interface Props { title: string; description: string; active?: string; canonical?: string; ogImage?: string; oembed?: string;
   article?: { publishedTime: Date; tags: string[] }; }
 const { title, description, active, canonical, ogImage, oembed, article } = Astro.props;
@@ -20,5 +21,6 @@ const { title, description, active, canonical, ogImage, oembed, article } = Astr
     <SiteHeader active={active} />
     <main><slot /></main>
     <SiteFooter />
+    <SearchPalette />
   </body>
 </html>

--- a/src/pages/[slug].astro
+++ b/src/pages/[slug].astro
@@ -11,10 +11,15 @@ export async function getStaticPaths() {
 }
 
 const { article } = Astro.props;
-const { Content, remarkPluginFrontmatter } = await render(article);
+const { Content, headings, remarkPluginFrontmatter } = await render(article);
 const rt = remarkPluginFrontmatter.minutesRead ?? '1 min read';
+// Contents index for longer entries: top-level sections only, and only when
+// there are enough of them for navigation to be worth the space.
+const toc = headings.filter((h) => h.depth === 2);
+const showToc = toc.length >= 3;
 const iso = article.data.date.toISOString().slice(0, 10);
-const ogImage = article.data.featuredImage?.src ?? article.data.coverImage;
+// Branded share card generated per article at build time (see pages/og/).
+const ogImage = `/og/${article.id}.png`;
 const oembed = oembedHref(article.id, Astro.site);
 
 // "Keep reading" — recommend a random other article. Picked at build time, so it
@@ -46,6 +51,16 @@ if (pick) {
       ? <Image class="hero-img" src={article.data.featuredImage} alt={article.data.title} widths={[400, 800, 1200]}
           sizes="(max-width: 680px) calc(100vw - 40px), 620px" loading="eager" fetchpriority="high" />
       : article.data.coverImage && <img class="hero-img" src={article.data.coverImage} alt={article.data.title} loading="eager" fetchpriority="high" decoding="async" />}
+    {showToc && (
+      <nav class="toc" aria-label="Contents">
+        <p class="eyebrow">// contents</p>
+        <ol>
+          {toc.map((h, i) => (
+            <li><a href={`#${h.slug}`}><span class="toc-idx">{String(i + 1).padStart(2, '0')}</span>{h.text}</a></li>
+          ))}
+        </ol>
+      </nav>
+    )}
     <div class="prose"><Content /></div>
     {rec && <KeepReading {...rec} />}
   </article>
@@ -66,6 +81,36 @@ if (pick) {
       };
       if (document.readyState === 'loading') document.addEventListener('DOMContentLoaded', enhance);
       else enhance();
+    })();
+  </script>
+  <script is:inline>
+    // Copy buttons on code blocks. Each pre is wrapped so the button can anchor
+    // to the box instead of scrolling away with wide code. JS-only, so no-JS
+    // readers just see plain code blocks.
+    (() => {
+      if (!navigator.clipboard) return;
+      document.querySelectorAll('.prose pre.astro-code').forEach((pre) => {
+        const wrap = document.createElement('div');
+        wrap.className = 'code-wrap';
+        pre.parentNode.insertBefore(wrap, pre);
+        wrap.appendChild(pre);
+        const btn = document.createElement('button');
+        btn.type = 'button';
+        btn.className = 'code-copy';
+        btn.textContent = 'copy';
+        btn.setAttribute('aria-label', 'Copy code to clipboard');
+        btn.addEventListener('click', async () => {
+          try {
+            await navigator.clipboard.writeText((pre.querySelector('code') ?? pre).innerText.trimEnd() + '\n');
+            btn.textContent = 'copied ✓';
+            btn.classList.add('did');
+          } catch {
+            btn.textContent = 'failed';
+          }
+          setTimeout(() => { btn.textContent = 'copy'; btn.classList.remove('did'); }, 1600);
+        });
+        wrap.appendChild(btn);
+      });
     })();
   </script>
   <script is:inline>
@@ -120,7 +165,17 @@ if (pick) {
     border-bottom: 1px solid var(--hairline); }
   .readout a { color: var(--signal); text-decoration: none; }
   .hero-img { width: 100%; height: auto; margin: 28px 0; }
+  .toc { margin-top: 28px; padding: 16px 0 6px; border-top: 1px solid var(--hairline); }
+  .toc ol { list-style: none; margin-top: 10px; }
+  .toc li { border-bottom: 1px solid var(--hairline); }
+  .toc li:last-child { border-bottom: 0; }
+  .toc a { display: flex; gap: 14px; align-items: baseline; padding: 9px 0;
+    font-family: var(--font-display); font-weight: 500; font-size: .95rem;
+    color: var(--graphite); text-decoration: none; }
+  .toc a:hover { color: var(--signal); }
+  .toc-idx { font-family: var(--font-mono); font-weight: 400; font-size: .74rem; color: var(--slate); }
   .prose { font-size: 1.15rem; line-height: 1.7; }
+  .prose :global(h2), .prose :global(h3) { scroll-margin-top: 24px; }
   .prose :global(img) { display: block; width: 100%; height: auto; margin: 1.5rem 0; }
   /* Loading placeholder: a soft shimmer while the bitmap streams in. The static
      background-color is the fallback when motion is reduced (animations are
@@ -154,6 +209,17 @@ if (pick) {
   .prose :global(a) { color: var(--signal); }
   .prose :global(pre) { font-family: var(--font-mono); font-size: .9rem; padding: 16px;
     border: 1px solid var(--hairline); overflow-x: auto; margin: 0 0 1.2rem; }
+  .prose :global(.code-wrap) { position: relative; margin: 0 0 1.2rem; }
+  .prose :global(.code-wrap pre) { margin: 0; }
+  .prose :global(.code-copy) { position: absolute; top: 8px; right: 8px;
+    font-family: var(--font-mono); font-size: .68rem; letter-spacing: .02em; padding: 4px 9px;
+    border: 1px solid var(--hairline); background: var(--surface); color: var(--slate);
+    cursor: pointer; opacity: 0; transition: opacity .12s, color .12s, border-color .12s; }
+  .prose :global(.code-wrap:hover .code-copy), .prose :global(.code-copy:focus-visible),
+  .prose :global(.code-copy.did) { opacity: 1; }
+  .prose :global(.code-copy:hover) { color: var(--signal); border-color: var(--signal); }
+  .prose :global(.code-copy.did) { color: var(--signal); border-color: var(--signal); }
+  @media (hover: none) { .prose :global(.code-copy) { opacity: 1; } }
   .prose :global(code) { font-family: var(--font-mono); font-size: .9em; }
   .prose :global(blockquote) { border-left: 3px solid var(--signal); padding-left: 1rem; color: var(--slate); margin-bottom: 1.1rem; }
   /* Link card for `{% embed url %}` tags — mirrors the mono/hairline brand. */

--- a/src/pages/og/[slug].png.js
+++ b/src/pages/og/[slug].png.js
@@ -1,0 +1,91 @@
+// Build-time branded share cards, one per article: the logbook masthead, the
+// entry's log line (idx · date · read time), and its title. Rendered with satori
+// (flexbox layout from plain object trees) and rasterized by resvg, using the
+// same fonts and design tokens as the site itself. public/og-default.png is the
+// hand-kept equivalent for pages that aren't articles — keep the two in sync if
+// the brand changes.
+import { getCollection, render } from 'astro:content';
+import { readFile } from 'node:fs/promises';
+import satori from 'satori';
+import { Resvg } from '@resvg/resvg-js';
+
+const BONE = '#EFEFEA';
+const GRAPHITE = '#15181B';
+const SLATE = '#565C63';
+const HAIRLINE = '#D5D6D0';
+const SIGNAL = '#2347FF';
+
+const fontFile = (pkg, file) =>
+  readFile(new URL(`../../../node_modules/@fontsource/${pkg}/files/${file}`, import.meta.url));
+
+const fonts = Promise.all([
+  fontFile('space-grotesk', 'space-grotesk-latin-700-normal.woff').then((data) => ({
+    name: 'Space Grotesk', weight: 700, style: 'normal', data,
+  })),
+  fontFile('space-grotesk', 'space-grotesk-latin-500-normal.woff').then((data) => ({
+    name: 'Space Grotesk', weight: 500, style: 'normal', data,
+  })),
+  fontFile('jetbrains-mono', 'jetbrains-mono-latin-400-normal.woff').then((data) => ({
+    name: 'JetBrains Mono', weight: 400, style: 'normal', data,
+  })),
+]);
+
+const el = (type, style, ...children) => ({
+  type,
+  props: { style, children: children.length === 1 ? children[0] : children },
+});
+
+function card({ idx, date, minutes, title, tags }) {
+  const titleSize = title.length > 55 ? 58 : title.length > 34 ? 70 : 82;
+  return el('div', {
+    display: 'flex', flexDirection: 'column', width: '1200px', height: '630px',
+    padding: '0 72px', backgroundColor: BONE, color: GRAPHITE,
+  },
+    el('div', {
+      display: 'flex', justifyContent: 'space-between', alignItems: 'baseline',
+      padding: '40px 0 28px', borderBottom: `2px solid ${HAIRLINE}`,
+    },
+      el('div', { display: 'flex', fontFamily: 'Space Grotesk', fontSize: '30px', letterSpacing: '0.02em' },
+        el('span', { fontWeight: 700 }, 'KEVIN ALEMAN'),
+        el('span', { fontWeight: 500, color: SLATE, marginLeft: '12px' }, '— LOGBOOK'),
+      ),
+      el('div', { display: 'flex', fontFamily: 'JetBrains Mono', fontSize: '22px', color: SLATE }, 'abcdev.netlify.app'),
+    ),
+    el('div', { display: 'flex', flex: 1, flexDirection: 'column', justifyContent: 'center' },
+      el('div', { display: 'flex', fontFamily: 'JetBrains Mono', fontSize: '22px', letterSpacing: '0.1em' },
+        el('span', { color: SIGNAL }, `// LOG ${String(idx).padStart(3, '0')}`),
+        el('span', { color: SLATE, marginLeft: '18px' }, `· ${date} · ${minutes}M READ`),
+      ),
+      el('div', {
+        display: 'flex', marginTop: '28px', fontFamily: 'Space Grotesk', fontWeight: 700,
+        fontSize: `${titleSize}px`, lineHeight: 1.06, letterSpacing: '-0.02em',
+      }, title),
+    ),
+    el('div', {
+      display: 'flex', justifyContent: 'space-between', padding: '26px 0 40px',
+      borderTop: `2px solid ${HAIRLINE}`, fontFamily: 'JetBrains Mono', fontSize: '20px', color: SLATE,
+    },
+      el('span', {}, tags.slice(0, 4).join(' · ')),
+      el('span', {}, 'by Kevin Aleman'),
+    ),
+  );
+}
+
+export async function getStaticPaths() {
+  const articles = await getCollection('articles', ({ data }) => !data.draft);
+  return articles.map((article) => ({ params: { slug: article.id }, props: { article } }));
+}
+
+export async function GET({ props }) {
+  const { article } = props;
+  const { remarkPluginFrontmatter } = await render(article);
+  const svg = await satori(card({
+    idx: article.data.idx,
+    date: article.data.date.toISOString().slice(0, 10),
+    minutes: parseInt(remarkPluginFrontmatter.minutesRead ?? '1', 10) || 1,
+    title: article.data.title,
+    tags: article.data.tags,
+  }), { width: 1200, height: 630, fonts: await fonts });
+  const png = new Resvg(svg, { fitTo: { mode: 'width', value: 1200 } }).render().asPng();
+  return new Response(png, { headers: { 'Content-Type': 'image/png' } });
+}

--- a/src/pages/stats.astro
+++ b/src/pages/stats.astro
@@ -1,0 +1,138 @@
+---
+import { getCollection, render } from 'astro:content';
+import Base from '../layouts/Base.astro';
+
+const arts = (await getCollection('articles', ({ data }) => !data.draft))
+  .sort((a, b) => a.data.date.getTime() - b.data.date.getTime());
+
+const entries = await Promise.all(arts.map(async (a) => {
+  const { remarkPluginFrontmatter } = await render(a);
+  const minutes = parseInt(remarkPluginFrontmatter.minutesRead ?? '1', 10) || 1;
+  // Word count from the raw markdown, so it's approximate (includes code).
+  const words = a.body ? a.body.split(/\s+/).filter(Boolean).length : 0;
+  return { id: a.id, idx: a.data.idx, title: a.data.title, date: a.data.date, tags: a.data.tags, minutes, words };
+}));
+
+const totalWords = entries.reduce((s, e) => s + e.words, 0);
+const totalMinutes = entries.reduce((s, e) => s + e.minutes, 0);
+const fmtWords = totalWords >= 1000 ? `${(totalWords / 1000).toFixed(1)}k` : String(totalWords);
+const fmtTime = totalMinutes >= 60 ? `${Math.floor(totalMinutes / 60)}h ${totalMinutes % 60}m` : `${totalMinutes}m`;
+
+// Posts per year, including the quiet years — gaps are part of the log.
+const firstYear = entries[0]?.date.getUTCFullYear() ?? new Date().getUTCFullYear();
+const lastYear = entries.at(-1)?.date.getUTCFullYear() ?? firstYear;
+const byYear = [];
+for (let y = firstYear; y <= lastYear; y++) {
+  byYear.push({ year: y, count: entries.filter((e) => e.date.getUTCFullYear() === y).length });
+}
+const maxCount = Math.max(...byYear.map((y) => y.count), 1);
+
+const tagCounts = new Map();
+for (const e of entries) for (const t of e.tags) tagCounts.set(t, (tagCounts.get(t) ?? 0) + 1);
+const topTags = [...tagCounts.entries()].sort((a, b) => b[1] - a[1] || a[0].localeCompare(b[0])).slice(0, 12);
+const maxTag = topTags[0]?.[1] ?? 1;
+
+const longest = entries.reduce((m, e) => (e.minutes > m.minutes ? e : m), entries[0]);
+const busiest = byYear.reduce((m, y) => (y.count > m.count ? y : m), byYear[0]);
+
+const tiles = [
+  { label: 'entries', value: String(entries.length) },
+  { label: 'words (approx)', value: fmtWords },
+  { label: 'total read time', value: fmtTime },
+  { label: 'logging since', value: String(firstYear) },
+];
+---
+<Base title="Stats — Kev's logbook" description="Numbers from the logbook: entries, words, read time, years, and tags." active="stats">
+  <div class="wrap stats">
+    <p class="eyebrow">// stats</p>
+    <h1>The log, in numbers</h1>
+
+    <div class="tiles">
+      {tiles.map((t) => (
+        <div class="tile">
+          <span class="tile-value">{t.value}</span>
+          <span class="tile-label">{t.label}</span>
+        </div>
+      ))}
+    </div>
+
+    <section>
+      <h2 class="eyebrow">entries per year</h2>
+      <div class="chart" role="img" aria-label={`Entries per year: ${byYear.map((y) => `${y.year}, ${y.count}`).join('; ')}`}>
+        {byYear.map((y) => (
+          <div class="bar-row">
+            <span class="bar-year">{y.year}</span>
+            <span class="bar-track"><span class="bar" style={`width:${(y.count / maxCount) * 100}%`}></span></span>
+            <span class="bar-count">{y.count}</span>
+          </div>
+        ))}
+      </div>
+    </section>
+
+    <section>
+      <h2 class="eyebrow">recurring tags</h2>
+      <div class="chart">
+        {topTags.map(([tag, count], i) => (
+          <a class="bar-row tag-row" href={`/#${encodeURIComponent(tag)}`}>
+            <span class="bar-year">{String(i + 1).padStart(2, '0')}</span>
+            <span class="tag-name">{tag}</span>
+            <span class="bar-track"><span class="bar" style={`width:${(count / maxTag) * 100}%`}></span></span>
+            <span class="bar-count">{count}</span>
+          </a>
+        ))}
+      </div>
+      <p class="footnote">tags link to the filtered logbook</p>
+    </section>
+
+    <section>
+      <h2 class="eyebrow">records</h2>
+      <ul class="records">
+        <li><span>longest entry</span><a href={`/${longest.id}`}>{longest.title}</a><span class="rec-val">{longest.minutes}m</span></li>
+        <li><span>busiest year</span><span class="rec-main">{busiest.year}</span><span class="rec-val">{busiest.count} entries</span></li>
+        <li><span>most-used tag</span><a href={`/#${encodeURIComponent(topTags[0]?.[0] ?? '')}`}>{topTags[0]?.[0]}</a><span class="rec-val">{topTags[0]?.[1]}×</span></li>
+      </ul>
+    </section>
+  </div>
+</Base>
+<style>
+  .stats { max-width: var(--measure); padding-top: 48px; }
+  h1 { font-family: var(--font-display); font-weight: 700; font-size: 2.4rem; margin: 14px 0 28px; }
+  section { margin-top: 40px; }
+
+  .tiles { display: grid; grid-template-columns: repeat(4, 1fr); gap: 0;
+    border: 1px solid var(--hairline); background: var(--surface); }
+  .tile { display: flex; flex-direction: column; gap: 6px; padding: 18px 20px; }
+  .tile + .tile { border-left: 1px solid var(--hairline); }
+  .tile-value { font-family: var(--font-display); font-weight: 700; font-size: 1.9rem; letter-spacing: -.01em; }
+  .tile-label { font-family: var(--font-mono); font-size: .7rem; letter-spacing: .1em;
+    text-transform: uppercase; color: var(--slate); }
+
+  .chart { margin-top: 14px; border-top: 1px solid var(--hairline); }
+  .bar-row { display: grid; grid-template-columns: 52px 1fr 34px; gap: 14px; align-items: center;
+    padding: 9px 0; border-bottom: 1px solid var(--hairline); font-family: var(--font-mono); font-size: .8rem; }
+  .tag-row { grid-template-columns: 28px 132px 1fr 34px; color: inherit; text-decoration: none; }
+  .tag-row:hover .tag-name { color: var(--signal); }
+  .bar-year { color: var(--slate); }
+  .tag-name { color: var(--graphite); overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+  .bar-track { display: block; height: 12px; }
+  .bar { display: block; height: 100%; background: var(--signal); min-width: 0; }
+  .bar-count { text-align: right; color: var(--graphite); }
+  .footnote { margin-top: 10px; font-family: var(--font-mono); font-size: .7rem; color: var(--slate); }
+
+  .records { list-style: none; margin-top: 14px; border-top: 1px solid var(--hairline); }
+  .records li { display: flex; gap: 14px; align-items: baseline; padding: 11px 0;
+    border-bottom: 1px solid var(--hairline); font-family: var(--font-mono); font-size: .8rem; }
+  .records li > span:first-child { color: var(--slate); flex: 0 0 132px; }
+  .records a, .rec-main { font-family: var(--font-display); font-weight: 500; font-size: .95rem;
+    color: var(--graphite); text-decoration: none; }
+  .records a:hover { color: var(--signal); }
+  .rec-val { margin-left: auto; color: var(--slate); }
+
+  @media (max-width: 640px) {
+    .tiles { grid-template-columns: repeat(2, 1fr); }
+    .tile:nth-child(3) { border-left: 0; }
+    .tile:nth-child(n + 3) { border-top: 1px solid var(--hairline); }
+    .tag-row { grid-template-columns: 28px 96px 1fr 34px; }
+    .records li > span:first-child { flex-basis: 96px; }
+  }
+</style>


### PR DESCRIPTION
Four new features, all in the existing "engineering logbook" design language:

## ⌘K search palette
- `SearchPalette.astro`, included on every page: opens with **⌘K / ctrl+K / `/`** or the new nav button (button stays hidden without JS)
- Searches a tiny build-time index (title, tags, excerpt — ~3 KB inlined JSON), no backend
- Every query token must match; results ranked title > tag > excerpt; full keyboard navigation; active row uses the logbook's signal-blue inversion

## Per-article social share cards
- `src/pages/og/[slug].png.js` renders a branded 1200×630 PNG per post at build time with **satori + resvg**, using the site's own fonts and tokens: masthead, `// LOG 011 · 2020-10-02 · 3M READ` line, title, tags
- Article `og:image`/`twitter:image` now point at the generated card (non-article pages keep `og-default.png`)

## Article TOC + code copy buttons
- `// contents` index of h2 sections on articles with 3+ sections, numbered logbook-style
- Copy button on every code block (hover-revealed, always visible on touch, flips to "copied ✓"); both are JS-enhanced with clean no-JS fallback

## /stats page
- Stat tiles (entries, ≈words, total read time, logging since), entries-per-year bars (quiet years included), recurring tags linking to the filtered logbook home, and a records list; added to the nav

## Verification
- `astro check`, all 33 unit tests, and the production build pass
- Verified end-to-end in headless Chromium: palette opens/filters/navigates by keyboard, TOC anchors jump, copy button writes to the clipboard, stats page renders in light + dark

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EbPtVeiUcnwPjxGb2de8so

---
_Generated by [Claude Code](https://claude.ai/code/session_01EbPtVeiUcnwPjxGb2de8so)_