### PR TITLE
Make the header nav wrap cleanly on phones

### DIFF
--- a/src/components/SiteHeader.astro
+++ b/src/components/SiteHeader.astro
@@ -25,22 +25,27 @@ const items = [
 </header>
 <style>
   header { border-bottom: 1px solid var(--hairline); }
-  .masthead { display: flex; align-items: baseline; justify-content: space-between; padding-block: 22px; }
+  .masthead { display: flex; align-items: center; justify-content: space-between;
+    gap: 12px 20px; padding-block: 22px; }
   .wordmark { font-family: var(--font-display); font-weight: 700; font-size: 1.05rem;
     letter-spacing: .02em; color: var(--graphite); text-decoration: none; }
   .wordmark span { color: var(--slate); font-weight: 500; }
-  nav { font-family: var(--font-mono); font-size: .8rem; }
-  nav a { color: var(--graphite); text-decoration: none; margin-left: 22px; }
+  /* Flex so every item is its own box: links wrap at item boundaries on narrow
+     screens (inline links with no whitespace between them can't break), and the
+     bordered toggle centers against the text links instead of sitting on a
+     mismatched baseline. */
+  nav { display: flex; flex-wrap: wrap; align-items: center; gap: 10px 22px;
+    font-family: var(--font-mono); font-size: .8rem; }
+  nav a { color: var(--graphite); text-decoration: none; }
   nav a:hover, nav a.active { color: var(--signal); }
   #search-open { font-family: var(--font-mono); font-size: .8rem; background: none; border: 0;
-    padding: 0; margin-left: 22px; color: var(--graphite); cursor: pointer; }
+    padding: 0; color: var(--graphite); cursor: pointer; }
   #search-open:hover { color: var(--signal); }
   #search-open kbd { font-family: var(--font-mono); font-size: .68rem; color: var(--slate);
     border: 1px solid var(--hairline); padding: 1px 5px; margin-left: 2px; }
   @media (max-width: 640px) {
-    .masthead { flex-direction: column; gap: 12px; align-items: flex-start; }
-    nav a { margin-left: 0; margin-right: 18px; }
-    #search-open { margin-left: 0; margin-right: 18px; }
+    .masthead { flex-direction: column; align-items: flex-start; }
+    nav { gap: 10px 16px; }
     #search-open kbd { display: none; }
   }
 </style>

--- a/src/components/ThemeToggle.astro
+++ b/src/components/ThemeToggle.astro
@@ -8,7 +8,7 @@
   #theme-toggle {
     font-family: var(--font-mono); font-size: .76rem; letter-spacing: .02em;
     background: none; border: 1px solid var(--hairline); padding: 5px 10px;
-    margin-left: 22px; cursor: pointer; color: var(--graphite);
+    cursor: pointer; color: var(--graphite);
     transition: border-color .12s, color .12s;
   }
   #theme-toggle:hover { color: var(--signal); border-color: var(--signal); }
@@ -19,7 +19,6 @@
     :root:not([data-theme="light"]) .on-light { display: none; }
     :root:not([data-theme="light"]) .on-dark { display: inline; }
   }
-  @media (max-width: 640px) { #theme-toggle { margin-left: 0; } }
 </style>
 <script is:inline>
   (() => {


### PR DESCRIPTION
Fixes the mobile header weirdness — two causes, both visible at ≤375px:

1. **The nav couldn't wrap.** The links render with no whitespace between them, so the line had no break opportunities; once "stats" and "search" joined the nav the row overflowed the viewport and "feed"/"contact" were clipped off-screen.
2. **The theme toggle sat on a mismatched baseline.** The bordered `dark ☾` button was baseline-aligned next to plain text links, so it looked misaligned on the wrapped row.

The nav is now a wrapping flexbox with uniform gaps: each link is its own box so lines break cleanly at item boundaries, and `align-items: center` seats the bordered toggle on the same visual line as the links (its old margin-left moves into the gap).

Verified at 320/344/375/390px in light and dark — nothing clips, rows wrap neatly — and the desktop header renders identically to before.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EbPtVeiUcnwPjxGb2de8so

---
_Generated by [Claude Code](https://claude.ai/code/session_01EbPtVeiUcnwPjxGb2de8so)_